### PR TITLE
feat: add YAML anchors/aliases with automatic deduplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ python generate_shader_defines.py --log "E:\Documents\my games\Skyrim Special Ed
 -   `--log`: Path to the log file (required).
 -   `--output`: Output YAML file (default: `shader_defines.yaml`).
 -   `--update-log`: Optional additional log (e.g., VR log) to merge configs.
+-   `--log-level`: Set the logging level (default: INFO, choices: DEBUG, INFO, WARNING, ERROR, CRITICAL).
 -   `-d/--debug`: Enable debug output.
 -   `-g/--gui`: Run with GUI (requires `gooey`).
 

--- a/hlslkit/compile_shaders.py
+++ b/hlslkit/compile_shaders.py
@@ -86,7 +86,7 @@ def flatten_defines(defines: list) -> list[str]:
         defines (list): List of defines, possibly nested.
 
     Returns:
-        list[str]: Flattened list of unique defines.
+        list[str]: Flattened list of unique defines, sorted for deterministic output.
 
     Example:
         >>> flatten_defines([["A=1", "B"], "C"])
@@ -99,7 +99,8 @@ def flatten_defines(defines: list) -> list[str]:
         else:
             flat.append(d)
     seen = set()
-    return [d for d in flat if not (d in seen or seen.add(d))]
+    result = [d for d in flat if d is not None and not (d in seen or seen.add(d))]
+    return sorted(result)
 
 
 def handle_termination(signum: int | None = None, frame: FrameType | None = None) -> None:

--- a/tests/test_compile_shaders_utils.py
+++ b/tests/test_compile_shaders_utils.py
@@ -58,7 +58,12 @@ def test_flatten_defines_with_duplicates():
     """Test flatten_defines with duplicate defines."""
     defines = [["A=1", "B"], ["B", "A=2"], ["C"]]
     result = flatten_defines(defines)
-    assert result == ["A=1", "B", "A=2", "C"]  # Duplicate "B" removed, but "A=1" and "A=2" are different values
+    assert result == [
+        "A=1",
+        "A=2",
+        "B",
+        "C",
+    ]  # Duplicate "B" removed, but "A=1" and "A=2" are different values, now sorted
 
 
 def test_flatten_defines_empty():
@@ -72,7 +77,7 @@ def test_flatten_defines_invalid():
     """Test flatten_defines with None in input."""
     defines = [["A=1"], None, ["B"]]
     result = flatten_defines(defines)
-    assert result == ["A=1", None, "B"]  # Matches actual behavior
+    assert result == ["A=1", "B"]  # None values filtered out, result sorted
 
 
 def test_normalize_path_empty_string():
@@ -143,7 +148,7 @@ def test_flatten_defines_mixed_types():
     """Test flatten_defines with mixed types."""
     defines = [["A=1"], "B=2", ["C=3"], None, ["D=4"]]
     result = flatten_defines(defines)
-    assert result == ["A=1", "B=2", "C=3", None, "D=4"]
+    assert result == ["A=1", "B=2", "C=3", "D=4"]  # None values filtered out, result sorted
 
 
 def test_flatten_defines_very_large_input():

--- a/tests/test_generate_shader_defines.py
+++ b/tests/test_generate_shader_defines.py
@@ -1,3 +1,4 @@
+import tempfile
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
@@ -6,11 +7,13 @@ from hlslkit.generate_shader_defines import (
     collect_tasks,
     count_compiling_lines,
     count_log_blocks,
+    generate_yaml_data,
     get_shader_type_from_entry,
     normalize_path,
     parse_log,
     parse_timestamp,
     populate_configs,
+    save_yaml,
 )
 
 
@@ -259,19 +262,227 @@ def test_count_compiling_lines_doctest(mock_open):
 
 @patch("hlslkit.generate_shader_defines.open")
 def test_count_log_blocks_doctest(mock_open):
-    """Test count_log_blocks function from doctest example."""
+    """Test count_log_blocks function."""
     mock_file = MagicMock()
-    mock_file.__enter__.return_value.__iter__.return_value = [
-        "[12:34:56.789] [123] [D] Compiling src/test1.hlsl main:vertex:1234 to A=1",
-        "[12:34:56.790] [123] [D] Shader logs:",
-        "[12:34:56.791] [123] [E] Failed to compile Pixel shader",
-        "[12:34:56.792] [123] [W] Shader compilation failed",
-        "[12:34:56.793] [123] [D] Adding Completed shader to map",
-        "[12:34:56.794] [123] [D] Some other log entry",
+    mock_file.__iter__.return_value = [
+        "[00:45:10.539] [35768] [D] Shader logs:",
+        "[00:45:10.540] [35768] [E] Failed to compile",
+        "[00:45:10.541] [35768] [W] Shader compilation failed",
+        "[00:45:10.542] [35768] [D] Adding Completed shader",
     ]
-    mock_open.return_value = mock_file
+    mock_open.return_value.__enter__.return_value = mock_file
+    assert count_log_blocks("log.txt") == 4
 
-    result = count_log_blocks("CommunityShaders.log")
-    assert (
-        result == 4
-    )  # Should count 4 log blocks (Shader logs, Failed to compile, compilation failed, Adding Completed)
+
+def test_generate_yaml_data_structure():
+    """Test that generate_yaml_data produces the expected structure."""
+    shader_configs = {
+        "test.hlsl": {
+            "PSHADER": [
+                {"entry": "main:1234", "defines": ["A=1", "B=2"]},
+                {"entry": "main:5678", "defines": ["A=1", "C=3"]},
+            ],
+            "VSHADER": [
+                {"entry": "main:9012", "defines": ["A=1", "D=4"]},
+            ],
+        }
+    }
+    warnings = {
+        "x3206:implicit truncation": {
+            "code": "X3206",
+            "message": "implicit truncation",
+            "instances": {
+                "test.hlsl:10": {"entries": ["main:1234"]},
+            },
+        }
+    }
+    errors = {}
+
+    yaml_data = generate_yaml_data(shader_configs, warnings, errors)
+
+    # Verify structure
+    assert "common_defines" in yaml_data
+    assert "common_pshader_defines" in yaml_data
+    assert "common_vshader_defines" in yaml_data
+    assert "common_cshader_defines" in yaml_data
+    assert "file_common_defines" in yaml_data
+    assert "warnings" in yaml_data
+    assert "errors" in yaml_data
+    assert "shaders" in yaml_data
+
+    # Verify shader structure
+    assert len(yaml_data["shaders"]) == 1
+    shader = yaml_data["shaders"][0]
+    assert shader["file"] == "test.hlsl"
+    assert "configs" in shader
+    assert "PSHADER" in shader["configs"]
+    assert "VSHADER" in shader["configs"]
+
+    # Verify PSHADER config
+    pshader_config = shader["configs"]["PSHADER"]
+    assert "common_defines" in pshader_config
+    assert "entries" in pshader_config
+    assert len(pshader_config["entries"]) == 2
+
+    # Verify entries structure
+    entry1 = pshader_config["entries"][0]
+    assert "entry" in entry1
+    assert "defines" in entry1
+    assert entry1["entry"] == "main:1234"
+
+
+def test_generate_yaml_data_with_anchors():
+    """Test that generate_yaml_data can produce YAML with anchors."""
+    shader_configs = {
+        "test.hlsl": {
+            "PSHADER": [
+                {"entry": "main:1234", "defines": ["A=1", "B=2"]},
+                {"entry": "main:5678", "defines": ["A=1", "B=2"]},  # Same defines
+            ],
+            "VSHADER": [
+                {"entry": "main:9012", "defines": ["A=1", "B=2"]},  # Same defines
+            ],
+        }
+    }
+    warnings = {}
+    errors = {}
+
+    yaml_data = generate_yaml_data(shader_configs, warnings, errors)
+
+    # Verify that common defines are extracted
+    assert "A=1" in yaml_data["common_defines"]
+    assert "B=2" in yaml_data["common_defines"]
+
+    # Verify that individual entries don't repeat common defines
+    pshader_config = yaml_data["shaders"][0]["configs"]["PSHADER"]
+    for entry in pshader_config["entries"]:
+        assert "A=1" not in entry["defines"]
+        assert "B=2" not in entry["defines"]
+
+
+def test_save_yaml_with_anchors():
+    """Test that save_yaml can handle YAML data with anchors."""
+    yaml_data = {
+        "common_defines": ["A=1", "B=2"],
+        "shaders": [
+            {
+                "file": "test.hlsl",
+                "configs": {
+                    "PSHADER": {
+                        "common_defines": ["A=1", "B=2"],
+                        "entries": [
+                            {"entry": "main:1234", "defines": []},
+                            {"entry": "main:5678", "defines": []},
+                        ],
+                    }
+                },
+            }
+        ],
+    }
+
+    # This should not raise an exception
+    with patch("builtins.open", create=True) as mock_open:
+        mock_file = MagicMock()
+        mock_open.return_value.__enter__.return_value = mock_file
+        save_yaml(yaml_data, "test.yaml")
+        mock_file.write.assert_called()
+
+
+def test_yaml_output_has_anchors_and_is_loadable():
+    """Test that save_yaml emits anchors for repeated lists and that the YAML is loadable."""
+    import yaml
+
+    from hlslkit.generate_shader_defines import save_yaml
+
+    common = ["A=1", "B=2"]
+    yaml_data = {
+        "common_defines": common,
+        "shaders": [
+            {
+                "file": "test.hlsl",
+                "configs": {
+                    "PSHADER": {
+                        "common_defines": common,
+                        "entries": [
+                            {"entry": "main:1234", "defines": []},
+                            {"entry": "main:5678", "defines": []},
+                        ],
+                    },
+                    "VSHADER": {
+                        "common_defines": common,
+                        "entries": [
+                            {"entry": "main:9012", "defines": []},
+                        ],
+                    },
+                },
+            }
+        ],
+    }
+    with tempfile.NamedTemporaryFile("r+") as tmp:
+        save_yaml(yaml_data, tmp.name)
+        tmp.seek(0)
+        output = tmp.read()
+    # Check for YAML anchor (&) and alias (*)
+    assert "&" in output and "*" in output
+    # Check that loading the YAML gives the same structure
+    loaded = yaml.safe_load(output)
+    assert loaded["common_defines"] == ["A=1", "B=2"]
+    assert loaded["shaders"][0]["configs"]["PSHADER"]["common_defines"] == ["A=1", "B=2"]
+    assert loaded["shaders"][0]["configs"]["VSHADER"]["common_defines"] == ["A=1", "B=2"]
+
+
+def test_yaml_deduplication_and_nested_anchors():
+    """Test that save_yaml deduplicates equal lists and emits anchors for flat and nested cases."""
+    import tempfile
+
+    import yaml
+
+    from hlslkit.generate_shader_defines import save_yaml
+
+    # Separate but equal lists
+    a = ["A=1", "B=2"]
+    b = ["A=1", "B=2"]  # different object, same value
+    c = ["A=1", "B=2"]
+    # Nested repeated list
+    nested1 = [["X", "Y"], ["X", "Y"]]
+    nested2 = [["X", "Y"], ["X", "Y"]]
+    yaml_data = {
+        "common_defines": a,
+        "shaders": [
+            {
+                "file": "test.hlsl",
+                "configs": {
+                    "PSHADER": {
+                        "common_defines": b,
+                        "entries": [
+                            {"entry": "main:1234", "defines": []},
+                            {"entry": "main:5678", "defines": []},
+                        ],
+                    },
+                    "VSHADER": {
+                        "common_defines": c,
+                        "entries": [
+                            {"entry": "main:9012", "defines": []},
+                        ],
+                    },
+                },
+            }
+        ],
+        "nested": nested1,
+        "nested2": nested2,
+    }
+    with tempfile.NamedTemporaryFile("r+") as tmp:
+        save_yaml(yaml_data, tmp.name)
+        tmp.seek(0)
+        output = tmp.read()
+    # Check for YAML anchor (&) and alias (*)
+    assert output.count("&") >= 2  # at least two anchors (flat and nested)
+    assert output.count("*") >= 2  # at least two aliases
+    # Check that loading the YAML gives the same structure (by value)
+    loaded = yaml.safe_load(output)
+    assert loaded["common_defines"] == ["A=1", "B=2"]
+    assert loaded["shaders"][0]["configs"]["PSHADER"]["common_defines"] == ["A=1", "B=2"]
+    assert loaded["shaders"][0]["configs"]["VSHADER"]["common_defines"] == ["A=1", "B=2"]
+    # Nested lists
+    assert loaded["nested"] == [["X", "Y"], ["X", "Y"]]
+    assert loaded["nested2"] == [["X", "Y"], ["X", "Y"]]


### PR DESCRIPTION
- Add custom AnchorDumper for YAML with anchor/alias support
- Implement deduplicate_lists() for automatic list deduplication
- Add make_hashable() helper for memoization keys
- Update save_yaml() to use deduplication and anchors
- Add comprehensive tests for anchor/alias functionality
- Fix type checking issues with pyright and ruff compliance

Reduces YAML file size and improves readability while maintaining
full compatibility with yaml.safe_load() and existing code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line option to control logging verbosity, allowing selection of log levels such as DEBUG, INFO, WARNING, ERROR, and CRITICAL.

* **Improvements**
  * Enhanced YAML output efficiency by implementing anchor deduplication, reducing repetition and optimizing file size.
  * Ensured consistent sorting of shader defines for deterministic and improved output.

* **Bug Fixes**
  * Fixed ordering and filtering of defines lists to exclude invalid entries and maintain sorted order.

* **Documentation**
  * Updated documentation to include the new logging option and reflect recent changes.

* **Tests**
  * Expanded and updated tests to cover YAML serialization, anchor deduplication, and new ordering logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->