### PR TITLE
chore(lint): fix ruff RUF059 unused-variable violations

### DIFF
--- a/hlslkit/compile_shaders.py
+++ b/hlslkit/compile_shaders.py
@@ -1573,7 +1573,7 @@ def analyze_and_report_results(
     """
     baseline_warnings = load_baseline_warnings(config_file)
     defines_lookup = build_defines_lookup(config_file)
-    new_warnings, all_warnings, errors, suppressed_warnings_count = process_warnings_and_errors(
+    new_warnings, _all_warnings, errors, suppressed_warnings_count = process_warnings_and_errors(
         results, baseline_warnings, suppress_warnings, defines_lookup
     )
     log_new_issues(new_warnings, errors, results, output_dir, defines_lookup)
@@ -1808,14 +1808,14 @@ def main() -> int:
 
     if stop_event.is_set() and results:
         suppress_warnings = [code.strip() for code in args.suppress_warnings.split(",") if code.strip()]
-        exit_code, total_new_warnings, error_count = analyze_and_report_results(
+        exit_code, _total_new_warnings, _error_count = analyze_and_report_results(
             results, args.config, args.output_dir, suppress_warnings, args.max_warnings
         )
         logging.warning("Compilation was interrupted")
         return exit_code
 
     suppress_warnings = [code.strip() for code in args.suppress_warnings.split(",") if code.strip()]
-    exit_code, total_new_warnings, error_count = analyze_and_report_results(
+    exit_code, _total_new_warnings, _error_count = analyze_and_report_results(
         results, args.config, args.output_dir, suppress_warnings, args.max_warnings
     )
     return exit_code

--- a/hlslkit/generate_shader_defines.py
+++ b/hlslkit/generate_shader_defines.py
@@ -172,7 +172,7 @@ def collect_tasks(lines: list[str]) -> list[CompilationTask]:
     for line in lines:
         compile_match = compile_regex.match(line)
         if compile_match:
-            timestamp, process_id, file_path, entry_point, compile_args = compile_match.groups()
+            _timestamp, process_id, file_path, entry_point, compile_args = compile_match.groups()
             defines = re.findall(r"\S+=[\w\d]+|\S+", compile_args.strip())
             tasks.append(
                 CompilationTask(
@@ -187,7 +187,7 @@ def collect_tasks(lines: list[str]) -> list[CompilationTask]:
 
         compiled_match = compiled_shader_regex.match(line)
         if compiled_match:
-            timestamp, process_id, entry_point = compiled_match.groups()
+            _timestamp, process_id, entry_point = compiled_match.groups()
             for task in reversed(tasks):
                 if task.process_id == process_id and task.entry_point == entry_point and task.end_time is None:
                     task.end_time = parse_timestamp(line)
@@ -196,7 +196,7 @@ def collect_tasks(lines: list[str]) -> list[CompilationTask]:
 
         completed_match = completed_regex.match(line)
         if completed_match:
-            timestamp, process_id, entry_point = completed_match.groups()
+            _timestamp, process_id, entry_point = completed_match.groups()
             for task in reversed(tasks):
                 if task.process_id == process_id and task.entry_point == entry_point and task.end_time is None:
                     task.end_time = parse_timestamp(line)
@@ -282,7 +282,7 @@ def collect_warnings_and_errors(
             line = lines[i].strip()
             shader_log_match = re.match(r"\[(\d{2}:\d{2}:\d{2}\.\d{3})\] \[(\d+)\] \[D\] Shader logs:", line)
             if shader_log_match:
-                timestamp, current_process_id = shader_log_match.groups()
+                _timestamp, current_process_id = shader_log_match.groups()
                 current_time = parse_timestamp(line)
                 current_warnings = []
                 pbar.update(1)

--- a/tests/test_buffer_scan.py
+++ b/tests/test_buffer_scan.py
@@ -80,9 +80,9 @@ def test_finditer_with_line_numbers_with_line_map():
     line_map = {0: 1, 2: 3}  # Adjusted to match actual function behavior
     result = list(finditer_with_line_numbers(pattern, text, line_map=line_map))
     assert len(result) == 2
-    line_number, match = result[0]
+    line_number, _match = result[0]
     assert line_number == 1  # Adjusted to match actual function behavior
-    line_number, match = result[1]
+    line_number, _match = result[1]
     assert line_number == 3  # Adjusted to match actual function behavior
 
 

--- a/tests/test_buffer_scan_scanner.py
+++ b/tests/test_buffer_scan_scanner.py
@@ -144,7 +144,7 @@ class TestFileScanner:
 
         mock_is_shader_io.side_effect = mock_is_shader_io_side_effect
 
-        hlsl_structs, cpp_structs = scanner.scan_for_structs()
+        hlsl_structs, _cpp_structs = scanner.scan_for_structs()
 
         # VSInput should be skipped
         assert "VSInput" not in hlsl_structs
@@ -168,7 +168,7 @@ class TestFileScanner:
         # Mock is_shader_io_struct to return False
         mock_is_shader_io.return_value = False
 
-        hlsl_structs, cpp_structs = scanner.scan_for_structs()
+        hlsl_structs, _cpp_structs = scanner.scan_for_structs()
 
         # Invalid data should be skipped
         assert "TestStruct" not in hlsl_structs
@@ -195,7 +195,7 @@ class TestFileScanner:
         # Mock is_shader_io_struct to return False
         mock_is_shader_io.return_value = False
 
-        hlsl_structs, cpp_structs = scanner.scan_for_structs()
+        hlsl_structs, _cpp_structs = scanner.scan_for_structs()
 
         # Both should be included
         assert "TestStruct" in hlsl_structs

--- a/tests/test_compile_shaders_includes.py
+++ b/tests/test_compile_shaders_includes.py
@@ -236,7 +236,7 @@ def test_initialize_compilation_single_file_multiple_variants(mock_isfile, mock_
     cpu_count = 4
     physical_cores = 2
     is_ci = False
-    max_workers, target_jobs, jobs_reason, tasks = initialize_compilation(args, cpu_count, physical_cores, is_ci)
+    _max_workers, _target_jobs, _jobs_reason, tasks = initialize_compilation(args, cpu_count, physical_cores, is_ci)
     # Should find all three variants of file.hlsl
     assert len(tasks) == 3
     # In single-file mode, tasks should use the absolute path of the file
@@ -270,7 +270,7 @@ def test_initialize_compilation_single_file_case_sensitive(mock_isfile, mock_exi
     cpu_count = 4
     physical_cores = 2
     is_ci = False
-    max_workers, target_jobs, jobs_reason, tasks = initialize_compilation(args, cpu_count, physical_cores, is_ci)
+    _max_workers, _target_jobs, _jobs_reason, tasks = initialize_compilation(args, cpu_count, physical_cores, is_ci)
     # Should not find any matches due to case sensitivity
     assert tasks == []
 
@@ -301,7 +301,7 @@ def test_initialize_compilation_single_file_with_extra_includes(mock_isfile, moc
     cpu_count = 4
     physical_cores = 2
     is_ci = False
-    max_workers, target_jobs, jobs_reason, tasks = initialize_compilation(args, cpu_count, physical_cores, is_ci)
+    _max_workers, _target_jobs, _jobs_reason, tasks = initialize_compilation(args, cpu_count, physical_cores, is_ci)
     # Should find the file and create tasks
     assert len(tasks) == 1
     assert os.path.basename(tasks[0][0]) == "file.hlsl"
@@ -329,7 +329,7 @@ def test_submit_tasks_with_extra_includes():
     target_jobs = 1
     futures = {}
     shader_dir = "/shaders"
-    new_active_tasks, new_task_iterator = submit_tasks(
+    _new_active_tasks, _new_task_iterator = submit_tasks(
         mock_executor, task_iterator, active_tasks, target_jobs, args, futures, shader_dir
     )
     mock_executor.submit.assert_called_once()
@@ -360,7 +360,7 @@ def test_submit_tasks_with_empty_extra_includes():
     target_jobs = 1
     futures = {}
     shader_dir = "/shaders"
-    new_active_tasks, new_task_iterator = submit_tasks(
+    _new_active_tasks, _new_task_iterator = submit_tasks(
         mock_executor, task_iterator, active_tasks, target_jobs, args, futures, shader_dir
     )
     mock_executor.submit.assert_called_once()
@@ -391,7 +391,7 @@ def test_submit_tasks_with_whitespace_extra_includes():
     target_jobs = 1
     futures = {}
     shader_dir = "/shaders"
-    new_active_tasks, new_task_iterator = submit_tasks(
+    _new_active_tasks, _new_task_iterator = submit_tasks(
         mock_executor, task_iterator, active_tasks, target_jobs, args, futures, shader_dir
     )
     mock_executor.submit.assert_called_once()

--- a/tests/test_generate_shader_defines.py
+++ b/tests/test_generate_shader_defines.py
@@ -155,7 +155,7 @@ def test_parse_log_with_conflicting_defines(mock_open):
         "[00:45:10.555] [1268] [D] Compiled shader Grass:Vertex:10007",
     ]
     mock_open.return_value = mock_file
-    shader_configs, warnings, errors = parse_log("log.txt")
+    shader_configs, _warnings, _errors = parse_log("log.txt")
     assert shader_configs["RunGrass.hlsl"]["VSHADER"] == [
         {
             "entry": "Grass:Vertex:10007",
@@ -199,7 +199,7 @@ def test_parse_log_with_error(mock_open):
         "[00:45:10.544] [37824] [D] Compilation failed",
     ]
     mock_open.return_value = mock_file
-    shader_configs, warnings, errors = parse_log("log.txt")
+    shader_configs, _warnings, errors = parse_log("log.txt")
     assert shader_configs["RunGrass.hlsl"]["VSHADER"] == [
         {"entry": "Grass:Vertex:4", "defines": ["D3DCOMPILE_DEBUG", "VSHADER"]}
     ]
@@ -243,7 +243,7 @@ def test_parse_log_doctest(mock_open):
     ]
     mock_open.return_value = mock_file
 
-    configs, warnings, errors = parse_log("CommunityShaders.log")
+    configs, _warnings, _errors = parse_log("CommunityShaders.log")
     expected_config = [{"entry": "main:vertex:1234", "defines": ["A=1"]}]
     assert configs["src/test.hlsl"]["VSHADER"] == expected_config
 

--- a/tests/test_generate_shader_defines_utils.py
+++ b/tests/test_generate_shader_defines_utils.py
@@ -297,7 +297,7 @@ class TestWarningErrorCollection:
         ]
         warnings = {}
         errors = {}
-        result_warnings, result_errors = collect_warnings_and_errors(lines, tasks, warnings, errors, 1)
+        _result_warnings, _result_errors = collect_warnings_and_errors(lines, tasks, warnings, errors, 1)
         # This should update the progress bar but not add errors since it doesn't match the exact pattern
 
 
@@ -318,7 +318,7 @@ class TestCommonDefines:
                 "CSHADER": [],
             },
         }
-        common_defines, define_counts, define_files = compute_common_defines(shader_configs)
+        common_defines, _define_counts, _define_files = compute_common_defines(shader_configs)
         assert "DEBUG=1" in common_defines
         assert "RELEASE=0" not in common_defines  # Not common across all shaders
 


### PR DESCRIPTION
## Summary
- CI was failing on `ruff check` due to 33 `RUF059` violations (unpacked tuple variables that are never used).
- Prefixed each unused variable with `_` per ruff's suggested fix, across `hlslkit/compile_shaders.py`, `hlslkit/generate_shader_defines.py`, and their corresponding tests.
- No behavior change — this only touches variable names that were already unused; all previously-used names in the same tuples are left untouched.

## Test plan
- [x] `ruff check .` passes with zero errors
- [x] `python -m pytest -q` — all 392 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Cleaned up variable naming to better follow Python conventions for intentionally unused values.
  - No functional behavior changed.

- **Tests**
  - Updated several tests to ignore unused return values more clearly.
  - Test coverage and assertions remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->